### PR TITLE
fix: Run vitest once in npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest run",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "test:bench": "vitest run tests/performance/benchmark.test.ts"


### PR DESCRIPTION
Update package.json test script from "vitest" to "vitest run" so that it executes tests and exits instead of hanging in watch mode.

Closes #4

---
*PR created automatically by Jules for task [17783402233964391614](https://jules.google.com/task/17783402233964391614) started by @socialawy*