### PR TITLE
chore: Exclude benchmarks from regular test suite (#4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
-    "test:bench": "vitest run tests/performance/benchmark.test.ts"
+    "test:bench": "vitest run tests/performance/benchmark.test.ts --config vitest.bench.config.ts"
   },
   "dependencies": {
     "@google/genai": "^1.39.0",

--- a/vitest.bench.config.ts
+++ b/vitest.bench.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    exclude: [...configDefaults.exclude, 'tests/performance/**'],
   },
 });


### PR DESCRIPTION
Resolves the final task of Issue #4 by separating benchmark test execution from the regular test suite. This was achieved by explicitly excluding the `tests/performance/**` path from the default Vitest configuration using `vitest.config.ts` and creating a new file, `vitest.bench.config.ts`, solely for benchmark execution. The `package.json` script `test:bench` was then updated to target this new configuration file.

---
*PR created automatically by Jules for task [17011363547748375835](https://jules.google.com/task/17011363547748375835) started by @socialawy*