### PR TITLE
chore: Add benchmarks to standard CI test script (Closes #4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "vitest run && npm run test:bench",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "test:bench": "vitest run tests/performance/benchmark.test.ts --config vitest.bench.config.ts"


### PR DESCRIPTION
Modifies `package.json` to execute `npm run test:bench` sequentially after `vitest run` in the `test` script, thereby ensuring that performance benchmarks execute during the CI test run without modifying workflow files.

---
*PR created automatically by Jules for task [5381260787389693739](https://jules.google.com/task/5381260787389693739) started by @socialawy*