### PR TITLE
chore: complete migration to Vitest (#1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -29,7 +29,7 @@ Describe the implementation approach.
 - [ ] Criterion 1
 - [ ] Criterion 2
 - [ ] npx tsc --noEmit passes
-- [ ] npx tsx test-modules.ts passes
+- [ ] npm run test passes
 
 ## Alternatives Considered
 Other approaches you considered and why you rejected them.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ Brief description of changes.
 
 ## Checklist
 - [ ] `npx tsc --noEmit` passes
-- [ ] `npx tsx test-modules.ts` passes
+- [ ] `npm run test` passes
 - [ ] New modules implement full SceneModule interface (init, update, dispose)
 - [ ] Three.js resources properly disposed (geometry, material, texture)
 - [ ] No console errors in browser


### PR DESCRIPTION
This PR updates the GitHub issue and pull request templates to reference the new Vitest command (`npm run test`) instead of the deprecated and removed `test-modules.ts` script. This ensures contributors receive accurate guidance on running tests before submitting PRs or issues.

---
*PR created automatically by Jules for task [690742337741118522](https://jules.google.com/task/690742337741118522) started by @socialawy*