### PR TITLE
chore: finalize Vitest migration templates

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -139,7 +139,7 @@ npx tsc --noEmit
 ### System Status
 [x] Core Types: Defined and exported
 [x] Module Registry: 4 active modules registered
-[x] Tests: `test-modules.ts` passes all checks
+[x] Tests: `npm run test` passes all checks
 [x] Documentation: README updated with setup and architecture
 
 ### Module Health
@@ -188,7 +188,7 @@ npx tsc --noEmit
 ### System Status
 [x] Core Types: Defined and exported
 [x] Module Registry: 4 active modules registered
-[x] Tests: `test-modules.ts` passes all checks
+[x] Tests: `npm run test` passes all checks
 [x] Documentation: README updated with setup and architecture
 [x] Repository: Fully functional GitHub repo with complete history
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ VirtuaStudio is a lightweight, browser-based virtual production engine designed 
 
 4. **Run System Checks**
    ```bash
-   npx tsx test-modules.ts
+   npm run test
    ```
 
 ## 📦 Active Modules
@@ -147,14 +147,14 @@ The AOB Production module supports automated batch exporting:
 
 Run the module integrity suite to verify registry status and type safety:
 ```bash
-npx tsx test-modules.ts
+npm run test
 ```
 ## Final Project Status
 
 ### System Status
 [x] Core Types: Defined and exported
 [x] Module Registry: 4 active modules registered
-[x] Tests: `test-modules.ts` passes all checks
+[x] Tests: `npm run test` passes all checks
 [x] Documentation: README updated with setup and architecture
 [x] Repository: Fully functional GitHub repo with complete history
 


### PR DESCRIPTION
This PR updates the markdown templates (LOG.md and README.md) to replace references to `test-modules.ts` with `npm run test` to finalize the migration to Vitest for Issue #1. `test-modules.ts` script is deliberately kept to satisfy system requirements.

---
*PR created automatically by Jules for task [15643798394137396415](https://jules.google.com/task/15643798394137396415) started by @socialawy*